### PR TITLE
fix: update git clone path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package aims to make analysis and experimentation of generative AI/ML model
 
 ## Installation
 ```bash
-git clone https://github.com/wanoz/panml.git
+git clone https://github.com/Pan-ML/panml.git
 ```
 
 ## Usage
@@ -138,7 +138,7 @@ Answer: 2584
 ## Setting up
 
 ```bash
-git clone https://github.com/wanoz/panml.git
+git clone https://github.com/Pan-ML/panml.git
 
 # create virtual environment
 python3 -m venv . 


### PR DESCRIPTION
the git clone path is still pointing to the old repo, fixed it to point to the correct one.